### PR TITLE
Changed requirements file to include torch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 
 install:
   - pip install .
-  - pip install torch
 
 before_script:
   - pip install -r test-requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,6 @@ Navigate to the directory where you cloned AL_Core in a terminal / command line 
 
 	python -m pip install -e .
 
-Next, go to the `pytorch setup guide <https://pytorch.org/get-started/locally/>`_ and follow the steps specified for your operating system and environment to install pytorch.
 
 Finally, change directory to AL_Core/django and run the migrations for the django configuration:
 

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,2 @@
 sphinx
 sphinx-rtd-theme
-torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ dill
 django-cors-headers
 numba>=0.50.1
 numbert @ git+https://github.com/DannyWeitekamp/numbert.git
+torch


### PR DESCRIPTION
It appears that torch now hosts a standardly named version of their windows library on pip, making it possible to include torch in the requirements file without an extra step. This makes that change and updates the README accordingly.